### PR TITLE
chore: change namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ Provide reusable typescript and react eslint configs
 1. Install the peerDependencies of eslint configs:
 
 ```sh
-npx install-peerdeps --dev @arbitrum/eslint-config-typescript/base
-npx install-peerdeps --dev @arbitrum/eslint-config-typescript/react
+npx install-peerdeps --dev @offchainlabs/eslint-config-typescript/base
+npx install-peerdeps --dev @offchainlabs/eslint-config-typescript/react
 ```
 
 2. Usage
@@ -14,8 +14,8 @@ npx install-peerdeps --dev @arbitrum/eslint-config-typescript/react
 ```ts
 module.exports = {
   extends: [
-    "@arbitrum/eslint-config-typescript/base",
-    "@arbitrum/eslint-config-typescript/react",
+    "@offchainlabs/eslint-config-typescript/base",
+    "@offchainlabs/eslint-config-typescript/react",
   ],
   // If needed, you can override with:
   overrides: [
@@ -42,13 +42,13 @@ Provide reusable prettier config
 1. Install the peerDependencies of prettier config:
 
 ```sh
-npx install-peerdeps --dev @arbitrum/prettier-config
+npx install-peerdeps --dev @offchainlabs/prettier-config
 ```
 
 2. Usage
 
 ```ts
 module.exports = {
-  extends: ["@arbitrum/prettier-config"],
+  extends: ["@offchainlabs/prettier-config"],
 };
 ```

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "arb-config",
+  "name": "offchain-labs-config",
   "version": "1.0.0",
   "description": "Shareable Offchain labs eslint and prettier config",
   "main": "index.js",

--- a/packages/eslint-typescript/package.json
+++ b/packages/eslint-typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@arbitrum/eslint-config-typescript",
+  "name": "@offchainlabs/eslint-config-typescript",
   "version": "1.0.0",
   "description": "Shareable Offchain labs eslint config",
   "main": "index.js",

--- a/packages/prettier/package.json
+++ b/packages/prettier/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@arbitrum/prettier-config",
+  "name": "@offchainlabs/prettier-config",
   "version": "1.0.0",
   "description": "Shareable Offchain labs prettier config",
   "main": "index.js",


### PR DESCRIPTION
Chane namespace from `arbitrum` to `offchainlabs`