### PR TITLE
feat(eslint)!: migrate to ESLint 9 flat config format

### DIFF
--- a/packages/eslint-config-typescript/.eslintrc
+++ b/packages/eslint-config-typescript/.eslintrc
@@ -1,3 +1,0 @@
-{
-  "extends": "./base.js"
-}

--- a/packages/eslint-config-typescript/README.md
+++ b/packages/eslint-config-typescript/README.md
@@ -2,86 +2,42 @@
 
 Provide reusable typescript and react eslint configs
 
-1. Install the peerDependencies of eslint configs:
+This package ships flat ESLint configs for ESLint 9+.
 
-```sh
-npx install-peerdeps -Y --dev @offchainlabs/eslint-config-typescript
+## Install
+
+Install `@offchainlabs/eslint-config-typescript` and its peer dependencies.
+
+## Usage (Flat Config / ESM)
+
+`eslint.config.mjs`
+
+```js
+import base from '@offchainlabs/eslint-config-typescript/base';
+import react from '@offchainlabs/eslint-config-typescript/react';
+
+export default [...base, ...react];
 ```
 
-2. Usage
+For Next.js projects, use `next` instead of `react`.
 
-[Eslint docs](https://eslint.org/docs/latest/use/configure/configuration-files#using-a-shareable-configuration-package)
+```js
+import base from '@offchainlabs/eslint-config-typescript/base';
+import next from '@offchainlabs/eslint-config-typescript/next';
 
-`eslintrc.js`
-
-```ts
-require('@offchainlabs/eslint-config-typescript/base');
-require('@offchainlabs/eslint-config-typescript/react');
-
-module.exports = {
-  extends: [
-    '@offchainlabs/eslint-config-typescript/base',
-    '@offchainlabs/eslint-config-typescript/react',
-  ],
-  // Override here
-};
+export default [
+  ...base,
+  ...next,
+  {
+    settings: {
+      next: {
+        rootDir: 'packages/my-app/',
+      },
+    },
+  },
+];
 ```
 
-`.eslintrc.yaml`, `.eslintrc.yml`
+`rootDir` can be a path (relative or absolute), a glob (i.e. `packages/*`), or an array of paths and/or globs.
 
-```yaml
-extends:
-  - '@offchainlabs/eslint-config-typescript/base'
-  - '@offchainlabs/eslint-config-typescript/react'
-
-rules:
-  # Override here
-```
-
-`.eslintrc.json`
-
-```JSON
-{
-  extends: [
-    '@offchainlabs/eslint-config-typescript/base',
-    '@offchainlabs/eslint-config-typescript/react'
-  ],
-  overrides: [...]
-}
-```
-
-`package.json`
-
-```JSON
-"eslintConfig": {
-  "extends": [
-    "@offchainlabs/eslint-config-typescript/base",
-    "@offchainlabs/eslint-config-typescript/react",
-  ],
-  "overrides": [...]
-}
-```
-
-## Note
-
-For nextjs based project,
-`"@offchainlabs/eslint-config-typescript/react"` should be removed in favor of `"@offchainlabs/eslint-config-typescript/next",`. It includes `react`, `react-hooks`, `jsx-a11y` and `import` configurations already.
-
-If you're using `@offchainlabs/eslint-config-typescript/next` in a project where Next.js isn't installed in your root directory (such as a monorepo), you need to update your `.eslintrc`:
-
-```JSON
-{
-  "extends": "next",
-  "settings": {
-    "next": {
-      "rootDir": "packages/my-app/"
-    }
-  }
-}
-```
-
-`rootDir` can be a path (relative or absolute), a glob (i.e. "packages/\*/"), or an array of paths and/or globs.
-
-see https://nextjs.org/docs/basic-features/eslint#rootdir
-
-This repo can be linted with itself by running `yarn run lint`
+For legacy `.eslintrc` extends support, use the previous major release.

--- a/packages/eslint-config-typescript/base.js
+++ b/packages/eslint-config-typescript/base.js
@@ -1,60 +1,81 @@
-const base = {
-  env: {
-    es6: true,
-  },
-  parser: '@typescript-eslint/parser',
-  parserOptions: {
-    ecmaVersion: 'latest', // Allows for the parsing of modern ECMAScript features
-    sourceType: 'module', // Allows for the use of imports
-  },
-  plugins: ['@typescript-eslint', 'prettier'],
-  extends: [
-    'plugin:@typescript-eslint/recommended',
-    'plugin:prettier/recommended', // Enables eslint-plugin-prettier and displays prettier errors as ESLint errors. Make sure this is always the last configuration in the extends array.
-  ],
-  rules: {
-    '@typescript-eslint/explicit-module-boundary-types': 'off', // allow type inference for function return type
-    '@typescript-eslint/member-delimiter-style': ['off'],
-    '@typescript-eslint/no-empty-function': 'off',
-    '@typescript-eslint/no-explicit-any': ['warn'],
-    '@typescript-eslint/no-non-null-assertion': ['off'],
-    '@typescript-eslint/no-unused-vars': 'error',
-    '@typescript-eslint/no-use-before-define': ['off'],
-    'no-empty-pattern': 'warn',
-    'no-useless-escape': 'warn',
-    'object-curly-spacing': ['error', 'always'],
-    'prefer-const': [2, { destructuring: 'all' }],
-    'prettier/prettier': ['error', { singleQuote: true }],
-    'no-await-in-loop': 'error',
-    '@typescript-eslint/ban-ts-comment': [
-      'error',
-      {
-        'ts-expect-error': 'allow-with-description',
-        'ts-ignore': 'allow-with-description',
-        'ts-nocheck': 'allow-with-description',
-        'ts-check': 'allow-with-description',
-      },
-    ],
-  },
-  overrides: [
-    {
-      // Test files
-      files: ['**/*.spec.ts', '**/*.test.ts', '__test__/**'],
-      env: {
-        'jest/globals': true,
-      },
-      plugins: ['jest'],
-      extends: ['plugin:jest/recommended'],
-      rules: {
-        'jest/expect-expect': [
-          'off',
-          {
-            assertFunctionNames: ['expect'],
-          },
-        ],
-      },
-    },
-  ],
+import tsEslintPlugin from '@typescript-eslint/eslint-plugin';
+import tsParser from '@typescript-eslint/parser';
+import prettierConfig from 'eslint-config-prettier';
+import prettierPlugin from 'eslint-plugin-prettier';
+import jestPlugin from 'eslint-plugin-jest';
+
+const jestGlobals = {
+  afterAll: 'readonly',
+  afterEach: 'readonly',
+  beforeAll: 'readonly',
+  beforeEach: 'readonly',
+  describe: 'readonly',
+  expect: 'readonly',
+  it: 'readonly',
+  jest: 'readonly',
+  test: 'readonly',
 };
 
-module.exports = base;
+export default [
+  {
+    name: '@offchainlabs/base',
+    languageOptions: {
+      parser: tsParser,
+      ecmaVersion: 'latest',
+      sourceType: 'module',
+    },
+    plugins: {
+      '@typescript-eslint': tsEslintPlugin,
+      prettier: prettierPlugin,
+    },
+    rules: {
+      ...(tsEslintPlugin?.configs?.recommended?.rules ?? {}),
+      ...(prettierConfig?.rules ?? {}),
+      '@typescript-eslint/explicit-module-boundary-types': 'off',
+      '@typescript-eslint/member-delimiter-style': ['off'],
+      '@typescript-eslint/no-empty-function': 'off',
+      '@typescript-eslint/no-explicit-any': ['warn'],
+      '@typescript-eslint/no-non-null-assertion': ['off'],
+      '@typescript-eslint/no-unused-vars': 'error',
+      '@typescript-eslint/no-use-before-define': ['off'],
+      'no-empty-pattern': 'warn',
+      'no-useless-escape': 'warn',
+      'object-curly-spacing': ['error', 'always'],
+      'prefer-const': [2, { destructuring: 'all' }],
+      'prettier/prettier': ['error', { singleQuote: true }],
+      'no-await-in-loop': 'error',
+      '@typescript-eslint/ban-ts-comment': [
+        'error',
+        {
+          'ts-expect-error': 'allow-with-description',
+          'ts-ignore': 'allow-with-description',
+          'ts-nocheck': 'allow-with-description',
+          'ts-check': 'allow-with-description',
+        },
+      ],
+    },
+  },
+  {
+    name: '@offchainlabs/base/jest',
+    files: [
+      '**/*.spec.{ts,tsx,js,jsx}',
+      '**/*.test.{ts,tsx,js,jsx}',
+      '__test__/**',
+    ],
+    languageOptions: {
+      globals: jestGlobals,
+    },
+    plugins: {
+      jest: jestPlugin,
+    },
+    rules: {
+      ...(jestPlugin?.configs?.recommended?.rules ?? {}),
+      'jest/expect-expect': [
+        'off',
+        {
+          assertFunctionNames: ['expect'],
+        },
+      ],
+    },
+  },
+];

--- a/packages/eslint-config-typescript/eslint.config.js
+++ b/packages/eslint-config-typescript/eslint.config.js
@@ -1,0 +1,5 @@
+import base from './base.js';
+
+const config = [...base];
+
+export default config;

--- a/packages/eslint-config-typescript/index.js
+++ b/packages/eslint-config-typescript/index.js
@@ -1,3 +1,3 @@
-export { base } from './base';
-export { react } from './react';
-export { next } from './next';
+export { default as base } from './base.js';
+export { default as react } from './react.js';
+export { default as next } from './next.js';

--- a/packages/eslint-config-typescript/next.js
+++ b/packages/eslint-config-typescript/next.js
@@ -1,6 +1,71 @@
-const next = {
-  parser: '@typescript-eslint/parser',
-  extends: ['next'],
-};
+import tsParser from '@typescript-eslint/parser';
+import nextPlugin from '@next/eslint-plugin-next';
+import importPlugin from 'eslint-plugin-import';
+import jsxA11yPlugin from 'eslint-plugin-jsx-a11y';
+import reactPlugin from 'eslint-plugin-react';
+import reactHooksPlugin from 'eslint-plugin-react-hooks';
 
-module.exports = next;
+export default [
+  {
+    name: '@offchainlabs/next',
+    files: ['**/*.{js,jsx,mjs,ts,tsx,mts,cts}'],
+    languageOptions: {
+      parser: tsParser,
+      ecmaVersion: 'latest',
+      sourceType: 'module',
+    },
+    plugins: {
+      '@next/next': nextPlugin,
+      'jsx-a11y': jsxA11yPlugin,
+      react: reactPlugin,
+      'react-hooks': reactHooksPlugin,
+      import: importPlugin,
+    },
+    settings: {
+      react: {
+        version: 'detect',
+      },
+      'import/parsers': {
+        '@typescript-eslint/parser': ['.ts', '.mts', '.cts', '.tsx', '.d.ts'],
+      },
+      'import/resolver': {
+        node: {
+          extensions: ['.js', '.jsx', '.ts', '.tsx'],
+        },
+        typescript: {
+          alwaysTryTypes: true,
+        },
+      },
+    },
+    rules: {
+      ...(reactPlugin?.configs?.recommended?.rules ?? {}),
+      ...(nextPlugin?.configs?.recommended?.rules ?? {}),
+      'react-hooks/rules-of-hooks': 'error',
+      'react-hooks/exhaustive-deps': 'warn',
+      'import/no-anonymous-default-export': 'warn',
+      'import/no-named-as-default': 'warn',
+      'import/no-named-as-default-member': 'warn',
+      'import/no-duplicates': 'warn',
+      'react/no-unknown-property': 'off',
+      'react/react-in-jsx-scope': 'off',
+      'react/prop-types': 'off',
+      'jsx-a11y/alt-text': [
+        'warn',
+        {
+          elements: ['img'],
+          img: ['Image'],
+        },
+      ],
+      'jsx-a11y/aria-props': 'warn',
+      'jsx-a11y/aria-proptypes': 'warn',
+      'jsx-a11y/aria-unsupported-elements': 'warn',
+      'jsx-a11y/role-has-required-aria-props': 'warn',
+      'jsx-a11y/role-supports-aria-props': 'warn',
+      'react/jsx-no-target-blank': 'off',
+      'react/jsx-uses-react': 'off',
+    },
+  },
+  {
+    ignores: ['.next/**', 'out/**', 'build/**', 'next-env.d.ts'],
+  },
+];

--- a/packages/eslint-config-typescript/package.json
+++ b/packages/eslint-config-typescript/package.json
@@ -1,8 +1,16 @@
 {
   "name": "@offchainlabs/eslint-config-typescript",
-  "version": "0.2.2",
+  "version": "1.0.0",
   "description": "Shareable Offchain labs eslint config",
   "main": "index.js",
+  "type": "module",
+  "exports": {
+    ".": "./index.js",
+    "./base": "./base.js",
+    "./react": "./react.js",
+    "./next": "./next.js",
+    "./package.json": "./package.json"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/OffchainLabs/config-monorepo.git",
@@ -15,29 +23,35 @@
   },
   "devDependencies": {
     "@offchainlabs/prettier-config": "^0.2.0",
-    "@typescript-eslint/eslint-plugin": "^5.48.2",
-    "@typescript-eslint/parser": "^5.48.2",
-    "eslint": "^8.32.0",
-    "eslint-config-next": "^13.2.4",
+    "@next/eslint-plugin-next": "^16.1.6",
+    "@typescript-eslint/eslint-plugin": "^8.54.0",
+    "@typescript-eslint/parser": "^8.54.0",
+    "eslint": "^9.36.0",
     "eslint-config-prettier": "^8.6.0",
+    "eslint-import-resolver-node": "^0.3.9",
+    "eslint-import-resolver-typescript": "^3.10.1",
+    "eslint-plugin-import": "^2.32.0",
     "eslint-plugin-jest": "^27.2.1",
     "eslint-plugin-jsx-a11y": "^6.7.1",
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-react": "^7.32.1",
-    "eslint-plugin-react-hooks": "^4.6.0",
+    "eslint-plugin-react-hooks": "^7.0.0",
     "prettier": "^2.8.3",
     "typescript": "^4.9.4"
   },
   "peerDependencies": {
-    "@typescript-eslint/eslint-plugin": "^5.48.2",
-    "@typescript-eslint/parser": "^5.48.2",
-    "eslint": "^8.32.0",
-    "eslint-config-next": "^13.2.4",
-    "eslint-config-prettier": "^8.6.0",
+    "@next/eslint-plugin-next": "^13.2.4 || ^14.0.0 || ^15.0.0 || ^16.0.0",
+    "@typescript-eslint/eslint-plugin": "^5.48.2 || ^8.0.0",
+    "@typescript-eslint/parser": "^5.48.2 || ^8.0.0",
+    "eslint": "^8.32.0 || ^9.0.0",
+    "eslint-config-prettier": "^8.6.0 || ^9.0.0 || ^10.0.0",
+    "eslint-import-resolver-node": "^0.3.6 || ^0.3.9",
+    "eslint-import-resolver-typescript": "^3.5.2 || ^3.10.1",
+    "eslint-plugin-import": "^2.29.0 || ^2.32.0",
     "eslint-plugin-jest": "^27.2.1",
-    "eslint-plugin-jsx-a11y": "^6.7.1",
-    "eslint-plugin-prettier": "^4.2.1",
-    "eslint-plugin-react": "^7.32.1",
-    "eslint-plugin-react-hooks": "^4.6.0"
+    "eslint-plugin-jsx-a11y": "^6.7.1 || ^6.10.0",
+    "eslint-plugin-prettier": "^4.2.1 || ^5.0.0",
+    "eslint-plugin-react": "^7.32.1 || ^7.37.0",
+    "eslint-plugin-react-hooks": "^4.6.0 || ^7.0.0"
   }
 }

--- a/packages/eslint-config-typescript/prettier.config.js
+++ b/packages/eslint-config-typescript/prettier.config.js
@@ -1,3 +1,5 @@
-module.exports = {
-  ...require('@offchainlabs/prettier-config'),
+import prettierConfig from '@offchainlabs/prettier-config';
+
+export default {
+  ...prettierConfig,
 };

--- a/packages/eslint-config-typescript/react.js
+++ b/packages/eslint-config-typescript/react.js
@@ -1,24 +1,33 @@
-const react = {
-  parser: '@typescript-eslint/parser',
-  parserOptions: {
-    ecmaVersion: 2022, // Allows for the parsing of modern ECMAScript features
-    sourceType: 'module', // Allows for the use of imports
-  },
-  plugins: ['react', 'jsx-a11y'],
-  extends: [
-    'plugin:jsx-a11y/recommended',
-    'plugin:react-hooks/recommended',
-    'plugin:react/recommended',
-  ],
-  settings: {
-    react: {
-      version: 'detect',
+import tsParser from '@typescript-eslint/parser';
+import jsxA11yPlugin from 'eslint-plugin-jsx-a11y';
+import reactPlugin from 'eslint-plugin-react';
+import reactHooksPlugin from 'eslint-plugin-react-hooks';
+
+export default [
+  {
+    name: '@offchainlabs/react',
+    languageOptions: {
+      parser: tsParser,
+      ecmaVersion: 2022,
+      sourceType: 'module',
+    },
+    plugins: {
+      react: reactPlugin,
+      'react-hooks': reactHooksPlugin,
+      'jsx-a11y': jsxA11yPlugin,
+    },
+    settings: {
+      react: {
+        version: 'detect',
+      },
+    },
+    rules: {
+      ...(reactPlugin?.configs?.recommended?.rules ?? {}),
+      ...(jsxA11yPlugin?.configs?.recommended?.rules ?? {}),
+      'react-hooks/rules-of-hooks': 'error',
+      'react-hooks/exhaustive-deps': 'warn',
+      'react/jsx-uses-react': 'off',
+      'react/react-in-jsx-scope': 'off',
     },
   },
-  rules: {
-    'react/jsx-uses-react': 'off', // we're using React 17+ so it's irrelevant
-    'react/react-in-jsx-scope': 'off', // we're using React 17+ so it's irrelevant
-  },
-};
-
-module.exports = react;
+];


### PR DESCRIPTION
- Convert all configs (base, react, next) from legacy extends to flat config arrays
- Upgrade to ESLint 9, TypeScript-eslint 8, react-hooks 7
- Expand next.js config with full plugin setup, a11y, and import rules

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":""}
```
-->
