### PR TITLE
chore(prettier-config): add package metadata

### DIFF
--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -8,6 +8,10 @@
     "url": "https://github.com/OffchainLabs/config-monorepo.git",
     "directory": "packages/prettier-config"
   },
+  "homepage": "https://github.com/OffchainLabs/config-monorepo/tree/main/packages/prettier-config#readme",
+  "bugs": {
+    "url": "https://github.com/OffchainLabs/config-monorepo/issues"
+  },
   "author": "Offchain Labs, Inc.",
   "license": "MIT",
   "peerDependencies": {


### PR DESCRIPTION
## Summary
- add npm `homepage` metadata for `@offchainlabs/prettier-config`
- add npm `bugs.url` metadata pointing to the repository issue tracker
- leave runtime code, dependencies, generated files, version fields, package files, and entry points unchanged

## Verification
- `node - <<'NODE' ...` package metadata assertion for `homepage` and `bugs.url`
- `npm pack --dry-run --ignore-scripts --json` in `packages/prettier-config`
- `git diff --check`