### PR TITLE
chore: add prettier config npm support metadata

### DIFF
--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -8,6 +8,10 @@
     "url": "https://github.com/OffchainLabs/config-monorepo.git",
     "directory": "packages/prettier-config"
   },
+  "homepage": "https://github.com/OffchainLabs/config-monorepo/tree/main/packages/prettier-config#readme",
+  "bugs": {
+    "url": "https://github.com/OffchainLabs/config-monorepo/issues"
+  },
   "author": "Offchain Labs, Inc.",
   "license": "MIT",
   "peerDependencies": {


### PR DESCRIPTION
﻿## Summary
- add npm homepage metadata pointing to the package README
- add npm bugs metadata pointing to the public issue tracker

## Validation
- `node -e "const p=require('./packages/prettier-config/package.json'); if(p.name!=='@offchainlabs/prettier-config'||p.homepage!=='https://github.com/OffchainLabs/config-monorepo/tree/main/packages/prettier-config#readme'||p.bugs?.url!=='https://github.com/OffchainLabs/config-monorepo/issues') process.exit(1)"`
- `npm pack --dry-run --ignore-scripts --json`
- `git diff --check`

Runtime code is unchanged; this is package metadata only.
