### PR TITLE
fix: add missing metadata fields to package.json

### DIFF
--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@offchainlabs/prettier-config",
   "version": "0.3.0",
+  "homepage": "https://github.com/OffchainLabs/config-monorepo",
+  "bugs": {
+    "url": "https://github.com/OffchainLabs/config-monorepo/issues"
+  },
   "description": "Shareable Offchain labs prettier config",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
Adds missing `bugs, homepage` metadata to `packages/prettier-config/package.json`.